### PR TITLE
Add delimiter option + unit test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,7 @@ class Logger {
       level = (LOG_LEVEL || 'info'),
       prefix = '',
       readable = (NODE_ENV != 'production'),
+      delimiter = '#',
     } = options
 
     if (typeof level != 'string') {
@@ -88,6 +89,7 @@ class Logger {
       color: !!color,
       readable: !!readable,
       threshold: level == 'none' ? Infinity : LEVELS[level],
+      delimiter,
     }
 
     for (const key in LEVELS) {
@@ -145,9 +147,9 @@ class Logger {
    */
 
   format(level, message, data) {
-    const { color, readable } = this.config
+    const { color, readable, delimiter } = this.config
     const value = LEVELS[level]
-    const flat = flatten(data, { delimiter: '#' })
+    const flat = flatten(data, { delimiter })
     const ctx = { ...flat, level, message }
     const string = logfmt.stringify(ctx)
 

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,9 @@ example.error('message', { data: [{ index: 1 }, { index: 2 }] })
 
 example.error(new Error('An error occured!'))
 
+const other = example.clone({ prefix: 'foo', delimiter: '.' })
+other.info('message', { data: [{ index: 1 }, { index: 2 }] })
+
 /**
  * Tests.
  */
@@ -43,7 +46,7 @@ describe('heroku-logger', () => {
       assert(l instanceof Logger)
     })
 
-    it('should set config', () => {
+    it('should set config (default values)', () => {
       const l = new Logger()
       assert.deepEqual(l.config, {
         level: 'info',
@@ -51,6 +54,26 @@ describe('heroku-logger', () => {
         prefix: '',
         readable: true,
         threshold: 2,
+        delimiter: '#',
+      })
+    })
+
+    it('should set config', () => {
+      const l = new Logger({
+        level: 'warn',
+        color: false,
+        prefix: 'foo',
+        readable: false,
+        threshold: 3,
+        delimiter: '.',
+      })
+      assert.deepEqual(l.config, {
+        level: 'warn',
+        color: false,
+        prefix: 'foo',
+        readable: false,
+        threshold: 3,
+        delimiter: '.',
       })
     })
 


### PR DESCRIPTION
Adds a `delimiter` option in Logger constructor to customize how nested object path parts are delimited. ie,

```
const logger = new Logger({ delimiter: '.' });
logger.debug('message', { data: [{ index: 1 }, { index: 2 }] });
```
will output `[debug] message data.0.index=1 data.1.index=2 level=debug message=message`
instead of `[debug] message data#0#index=1 data#1#index=2 level=debug message=message`