### PR TITLE
hide level and message from output in development, fix #13

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,9 @@ class Logger {
     const { color, readable, delimiter } = this.config
     const value = LEVELS[level]
     const flat = flatten(data, { delimiter })
-    const ctx = { ...flat, level, message }
+    const ctx = NODE_ENV == 'development'
+      ? { ...flat }
+      : { ...flat, level, message }
     const string = logfmt.stringify(ctx)
 
     if (readable && color) {

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ class Logger {
     const { color, readable, delimiter } = this.config
     const value = LEVELS[level]
     const flat = flatten(data, { delimiter })
-    const ctx = NODE_ENV == 'development'
+    const ctx = NODE_ENV != 'production'
       ? { ...flat }
       : { ...flat, level, message }
     const string = logfmt.stringify(ctx)

--- a/test/index.js
+++ b/test/index.js
@@ -90,7 +90,7 @@ describe('heroku-logger', () => {
   it('should accept a delimiter option', () => {
     const l = new Logger({ delimiter: '.', color: false })
     const string = l.format('info', 'message', { key: { nested: 'value' }})
-    assert.equal(string, '[info] message key.nested=value level=info message=message')
+    assert.equal(string, '[info] message key.nested=value')
   })
 
   it('should not fail on circular data', () => {


### PR DESCRIPTION
Note the test [it should accept a delimiter option](https://github.com/fl0w/heroku-logger/blob/7edba5c8e144640c5832db18dd9aa249323c2504/test/index.js#L93) had to be adjusted to accomplish this.

This hides level and message when NODE_ENV is not production from output since, as described in issue, it's already presented using other means.